### PR TITLE
stage0 linkerscript for Wii System Menu 4.3 (NTSC)

### DIFF
--- a/stage0/WII_SM4_3_NTSC.lds
+++ b/stage0/WII_SM4_3_NTSC.lds
@@ -1,0 +1,41 @@
+/*  Copyright 2019  Dexter Gerig  <dexgerig@gmail.com>
+    
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+OUTPUT_FORMAT("elf32-powerpc")
+OUTPUT_ARCH(powerpc:common)
+
+ENTRY(_start)
+
+SECTIONS {
+	/* Adjust app specific settings here. */
+	sdp_cb = 0x811731e0;
+	l2cb = 0x811725e0;
+	switch_addr = 0x8168ee70;
+	switch_break = 0x815ade08;
+	payload_addr = 0x80004000;
+	
+	. = (0x80001800 - 0xc);
+	dest = (. + 0xc);
+	.app_settings : {
+		LONG(sdp_cb)
+		LONG(l2cb)
+		LONG(switch_addr)
+	}
+
+	.start : {
+		stage0.o(*)
+	}
+}


### PR DESCRIPTION
_Should_ be correct. In my Dolphin RAM-dump, `0x80004000` appears to be unused while waiting for a Wiimote to connect (so I assume this SM is similar enough to the Mini one).

This is un-tested on hardware.